### PR TITLE
chore(CI/CD): bump version 0.1.2 -> 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2024-10-21
+
 ### Added
 
 - Option to change colors
@@ -42,7 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Plotting basic functionality with CLI
 
-[Unreleased]: https://github.com/RaczeQ/pixel-map/compare/0.1.2...HEAD
+[Unreleased]: https://github.com/RaczeQ/pixel-map/compare/0.2.0...HEAD
+
+[0.2.0]: https://github.com/RaczeQ/pixel-map/compare/0.1.2...0.2.0
 
 [0.1.2]: https://github.com/RaczeQ/pixel-map/compare/0.1.1...0.1.2
 

--- a/pixel_map/__init__.py
+++ b/pixel_map/__init__.py
@@ -1,4 +1,4 @@
 """Pixel-map library."""
 
 __app_name__ = "pixel-map"
-__version__ = "0.1.2"
+__version__ = "0.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pixel-map"
-version = "0.1.2"
+version = "0.2.0"
 description = "A Python CLI tool for plotting geo files in the terminal"
 authors = [{ name = "Kamil Raczycki", email = "kraczycki@kraina.ai" }]
 dependencies = [
@@ -108,7 +108,7 @@ close-quotes-on-newline = true
 wrap-one-line = true
 
 [tool.bumpver]
-current_version = "0.1.2"
+current_version = "0.2.0"
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "chore(CI/CD): bump version {old_version} -> {new_version}"
 commit = true


### PR DESCRIPTION
### Added

- Option to change colors
- Option to change opacity
- Option to change basemap
- Default light and dark style
- Single letter flags to the CLI

### Changed

- Subtitle rendering

### Fixed

- Canvas not filling the space fully