### PR TITLE
chore(CI/CD): bump version 0.2.1 -> 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2024-10-23
+
 ## [0.2.1] - 2024-10-23
 
 ### Added
@@ -56,7 +58,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Plotting basic functionality with CLI
 
-[Unreleased]: https://github.com/RaczeQ/pixel-map/compare/0.2.1...HEAD
+[Unreleased]: https://github.com/RaczeQ/pixel-map/compare/0.2.2...HEAD
+
+[0.2.2]: https://github.com/RaczeQ/pixel-map/compare/0.2.1...0.2.2
 
 [0.2.1]: https://github.com/RaczeQ/pixel-map/compare/0.2.0...0.2.1
 

--- a/pixel_map/__init__.py
+++ b/pixel_map/__init__.py
@@ -1,4 +1,4 @@
 """Pixel-map library."""
 
 __app_name__ = "pixel-map"
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pixel-map"
-version = "0.2.1"
+version = "0.2.2"
 description = "A Python CLI tool for plotting geo files in the terminal"
 authors = [{ name = "Kamil Raczycki", email = "kraczycki@kraina.ai" }]
 dependencies = [
@@ -128,7 +128,7 @@ close-quotes-on-newline = true
 wrap-one-line = true
 
 [tool.bumpver]
-current_version = "0.2.1"
+current_version = "0.2.2"
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "chore(CI/CD): bump version {old_version} -> {new_version}"
 commit = true


### PR DESCRIPTION
### Added

- Option to pass console width and height
- Option to pass plotting DPI

### Fixed

- Automatic bounds clipping to the EPSG:3857 limits
- Capped minimal contextily zoom at 0